### PR TITLE
relax elixir version to allow 0.13.0 to be used as well

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Pogo.Mixfile do
   def project do
     [ app: :pogo,
       version: "0.0.1",
-      elixir: "~> 0.12.0",
+      elixir: "~> 0.12",
       deps: deps ]
   end
 


### PR DESCRIPTION
Not sure what version pogo is aiming to target, so went with `~> 0.12` to be safe.

Considered going with `~> 0.13.0`, but that would lock out existing users on ~ 0.12.0 still.

Also considered `~> 0.12.0 or ~> 0.13.0`, but that just doesn't make as much sense as just relaxing it.
